### PR TITLE
feat(module): add ability to use Steam 64 ID

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,9 @@ programs.steam.config = {
     };
   }
 
-  # Configuration per user's steamID3
-  # Your steamID3 can be found using https://steamid.io/lookup or in ~/.steam/steam/userdata
-  users."987654321".apps = {
+  # Configuration per user's SteamID64
+  # You can find your SteamID64 through https://steamid.io/lookup
+  users."98765432123456789".apps = {
     # Per user config only supports launchOptions, compat tools must be set globally
     "438100".launchOptions = ''env -u TZ PRESSURE_VESSEL_FILESYSTEMS_RW="$XDG_RUNTIME_DIR/wivrn/comp_ipc" %command%'';
 


### PR DESCRIPTION
The Steam 3 ID (used in `.steam/steam/userdata`) can easily be obtained from a Steam 64 ID (more common, found in user profile link).

More about that [here](https://developer.valvesoftware.com/wiki/SteamID) and [here](https://gist.github.com/bcahue/4eae86ae1d10364bb66d).