### PR TITLE
feat(module): abstract launch options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,12 @@ Manage Steam launch options and compatibility tools declaratively through [Home 
 
 > [!WARNING]
 > This flake is in early development and may be unstable
-> 
+>
 > Please report bugs or request features via the [issues tab](https://github.com/different-name/steam-launch.nix/issues)
 
 > [!IMPORTANT]  
 > **Steam must be closed** when writing to the Steam config files, either close Steam manually before activating your configuration, or enable `programs.steam.config.closeSteam` to close Steam on activation
-> 
+>
 > With this option, Steam will not be closed unless a new game is configured or a compatibility tool is changed
 
 ## Install
@@ -59,6 +59,36 @@ programs.steam.config = {
     "438100".launchOptions = ''env -u TZ PRESSURE_VESSEL_FILESYSTEMS_RW="$XDG_RUNTIME_DIR/wivrn/comp_ipc" %command%'';
 
     "620".launchOptions = "-vulkan";
+
+    # You can also use abstracted Nix options
+    "553850".launchOptions = {
+      # Environment variables to export
+      env = {
+        PROTON_USE_NTSYNC = true;
+        # This unsets the variable
+        TZ = null;
+      };
+      # Arguments for the game's executable (%command% <...>)
+      args = [
+        "-force-vulkan"
+        "--use-d3d11"
+        "+connect_lobby"
+        "-1"
+      ];
+      # Programs to wrap the game with (<...> %command%)
+      wrappers = [
+        (lib.getExe' pkgs.mangohud "mangohud")
+        "gamemoderun"
+      ];
+      # Extra bash code to run before executing the game
+      extraConfig = ''
+        if [[ "$*" == *"-force-vulkan"* ]]; then
+          export PROTON_ENABLE_WAYLAND=1
+        fi
+      '';
+    };
+
+    "1144200".launchOptions.env.WINEDLLOVERRIDES = "d3dcompiler_47=n;dxgi=n";
 
     # you can also use a package instead of a string, %command% will be passed to it
     # here's an example script that skips the Warhammer 40k Darktide launcher


### PR DESCRIPTION
This adds `optsBefore` and `optsAfter`.
These can be used instead of `launchOptions` to append options _before_ and _after_ the `%command%`.

When either of those are set, `launchOptions`'s default is changed to it. This means that `launchOptions` can still be set and will take priority over `opts{Before,Ater}` options.