### PR TITLE
fix: use `stdenv.hostPlatform.system`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1761907660,
+        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
         "type": "github"
       },
       "original": {

--- a/modules/steam-config.nix
+++ b/modules/steam-config.nix
@@ -226,7 +226,7 @@ in
     enable = lib.mkEnableOption "Steam user config store management";
 
     package = lib.mkOption {
-      default = inputs.self.packages.${pkgs.system}.steam-config-patcher;
+      default = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.steam-config-patcher;
       description = "The steam-config-patcher package to use.";
       type = types.package;
     };


### PR DESCRIPTION
Updated today and I'm getting the following warning:
```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```
This PR simply changes `pkgs.system` to `pkgs.stdenv.hostPlatform.system`.