### PR TITLE
Make the default compat-tool (ID of 0) set correct priority (75)

### DIFF
--- a/modules/steam-config.nix
+++ b/modules/steam-config.nix
@@ -307,7 +307,7 @@ in
                 CompatToolMapping = lib.mapAttrs (_: app: {
                   name = app.compatTool;
                   config = "";
-                  priority = "250";
+                  priority = if (app.id == 0) then "75" else "250";
                 }) compatToolConfigs;
               };
             };


### PR DESCRIPTION
Steam seems to be using the "priority" of 75 for the default compat-tool (ID of 0). This change simply adds some logic to check if the ID is 0 and then sets the priority to 75 instead of always setting it to 250.