### PR TITLE
docs: clarify escaping for arguments with spaces

### DIFF
--- a/options.md
+++ b/options.md
@@ -62,11 +62,11 @@ attribute set of (submodule)
   # App IDs can be provided through the `id` property
   spin-rhythm = {
     id = 1058830;
-    launchOptions = "DVXK_ASYNC=1 gamemoderun %command%";
+    launchOptionsStr = "DVXK_ASYNC=1 gamemoderun %command%";
   };
 
   # Or be provided through the `<name>`
-  "620".launchOptions = "-vulkan";
+  "620".launchOptionsStr = "-vulkan";
 }
 ````
 
@@ -155,12 +155,14 @@ null or (submodule) or (optionally newline-terminated) single-line string or pac
   # Arguments for the game's executable (%command% <...>)
   args = [
     "-force-vulkan"
+    "-provider" "Portal" # Arguments with a space must be escaped separately, instead of "-provider Portal"
   ];
 
   # Programs to wrap the game with (<...> %command%)
   wrappers = [
     (lib.getExe pkgs.gamemode)
     "mangohud"
+    "gamescope" "-W" "1920" "-H" "1080" "--"
   ];
 
   /*
@@ -277,11 +279,11 @@ attribute set of (submodule)
   # App IDs can be provided through the `id` property
   spin-rhythm = {
     id = 1058830;
-    launchOptions = "DVXK_ASYNC=1 gamemoderun %command%";
+    launchOptionsStr = "DVXK_ASYNC=1 gamemoderun %command%";
   };
 
   # Or be provided through the `<name>`
-  "620".launchOptions = "-vulkan";
+  "620".launchOptionsStr = "-vulkan";
 }
 ````
 
@@ -462,12 +464,14 @@ null or (submodule) or (optionally newline-terminated) single-line string or pac
   # Arguments for the game's executable (%command% <...>)
   args = [
     "-force-vulkan"
+    "-provider" "Portal" # Arguments with a space must be escaped separately, instead of "-provider Portal"
   ];
 
   # Programs to wrap the game with (<...> %command%)
   wrappers = [
     (lib.getExe pkgs.gamemode)
     "mangohud"
+    "gamescope" "-W" "1920" "-H" "1080" "--"
   ];
 
   /*


### PR DESCRIPTION
After a lot of troubleshooting why gamescope would randomly fail as well as some strange errors I wasn't expecting, I realised that I was escaping command line arguments incorrectly.

For example, I had `wrappers = [ "gamescope -W 2560 -H 1440 --" ]`, and couldn't figure out why it was failing to launch. Even `"gamescope" "-W 2560" "-H 1440" "--"` didn't work. What was actually needed was  `"gamescope" "-W" "2560" "-H" "1440" "--"`
The same also applies for regular game arguments - I was having issues signing in to Guild Wars 2, and it was because I was passing `"-provider Portal"` rather than `"-provider" "Portal"`.

I know this is common syntax in nix (I know I've used it in `system.autoUpgrade.flags`), but it's a bit counterintuitive to a beginner considering how flags are normally set and escaped in steam launch options. I've made a couple of tweaks to the documentation to make it clearer how arguments like that should be escaped, with a specific example for `gamescope` too as it's a common wrapper.

I've also fixed a couple of instances of `launchOptions` that should be `launchOptionsStr`