### PR TITLE
feat: per-app file drops via apps.<name>.files

### DIFF
--- a/modules/submodules/steam-app.nix
+++ b/modules/submodules/steam-app.nix
@@ -3,25 +3,152 @@
   pkgs,
   dataDir,
 }:
-{ name, ... }:
+{ name, config, ... }:
 let
   inherit (lib) types;
   baseAppModule = import ./base-app.nix { inherit lib pkgs dataDir; };
+
+  fileOpSubmodule = types.submodule (
+    { config, ... }:
+    {
+      options = {
+        empty = lib.mkOption {
+          type = types.bool;
+          default = false;
+          description = "Replace the file with an empty (0-byte) file.";
+        };
+
+        source = lib.mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "Replace the file with contents from this store path.";
+        };
+
+        mode = lib.mkOption {
+          type = types.enum [
+            "replace"
+            "create"
+            "init"
+          ];
+          default = "replace";
+          description = ''
+            How to handle a missing target.
+
+            - `replace` (default): only act when the target already exists; otherwise
+              skip. A backup of the original is written next to the target on first
+              apply.
+            - `create`: create the target (and parent directories) if absent; replace
+              it otherwise. No backup is written when the target did not exist.
+            - `init`: like `create` but only on first apply. If the target already
+              exists, leave it alone, even if its content differs from the source.
+              Use this for files the application is expected to write back to (in-game
+              overlay configs, save files). To push a new template, delete the target
+              and re-run.
+          '';
+        };
+
+        location = lib.mkOption {
+          type = types.enum [
+            "install"
+            "prefix"
+          ];
+          default = "install";
+          description = ''
+            Root the relative target path is resolved against.
+
+            - `install` (default): the Steam install directory
+              (`steamapps/common/<dir>`).
+            - `prefix`: the Proton/Wine prefix root
+              (`steamapps/compatdata/<appid>/pfx`). Use this for mods that write into
+              the game's user storage under `drive_c/users/steamuser/AppData/...`.
+          '';
+        };
+
+        # Resolved source path passed to the patcher. Hidden so callers see the
+        # `empty`/`source` pair, while the patcher only deals with a single path.
+        resolvedSource = lib.mkOption {
+          type = types.path;
+          default =
+            if config.empty then
+              pkgs.runCommand "steam-app-empty-file" { } "touch $out"
+            else if config.source != null then
+              pkgs.runCommand "steam-config-nix-file-source" { } ''
+                cp ${config.source} $out
+              ''
+            else
+              throw "steam-config-nix: file op needs `empty = true` or a `source` path";
+          visible = false;
+          internal = true;
+          readOnly = true;
+        };
+      };
+    }
+  );
 in
 {
   imports = [ baseAppModule ];
 
-  options.id = lib.mkOption {
-    type = types.int;
-    default = lib.strings.toIntBase10 name;
-    defaultText = lib.literalExpression "lib.strings.toIntBase10 <name>";
-    example = 438100;
-    description = ''
-      The Steam App ID.
+  options = {
+    id = lib.mkOption {
+      type = types.int;
+      default = lib.strings.toIntBase10 name;
+      defaultText = lib.literalExpression "lib.strings.toIntBase10 <name>";
+      example = 438100;
+      description = ''
+        The Steam App ID.
 
-      App IDs can be found through the game's store page URL.
+        App IDs can be found through the game's store page URL.
 
-      If an ID is not provided, the app's `<name>` will be used.
-    '';
+        If an ID is not provided, the app's `<name>` will be used.
+      '';
+    };
+
+    files = lib.mkOption {
+      type = types.attrsOf fileOpSubmodule;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          # Stub a file with empty content (e.g. an unwanted intro video).
+          "path/to/intro.bik".empty = true;
+
+          # Drop a DLL alongside the game executable.
+          "some-shim.dll" = {
+            source = "''${pkgs.someShimPackage}/some-shim.dll";
+            mode = "create";
+          };
+
+          # First-apply config that the game's overlay edits in place.
+          # The template is written once; subsequent activations leave any
+          # in-game tweaks alone.
+          "some-config.ini" = {
+            source = ./some-config.ini;
+            mode = "init";
+          };
+
+          # Drop a file into the Wine prefix's user storage.
+          "drive_c/users/steamuser/AppData/Local/<vendor>/<game>/mods/foo.xml" = {
+            source = ./foo.xml;
+            location = "prefix";
+            mode = "create";
+          };
+        }
+      '';
+      description = ''
+        Files to drop into the game's install directory or Proton prefix.
+
+        Keyed by path relative to `location`'s root. Use this for asset
+        replacements, intro-skip stubs, DLL injections, or first-apply config
+        templates the game writes back to.
+
+        Backups of replaced files are written once next to the target with a
+        `.steam-config-nix-backup` suffix on first apply.
+      '';
+    };
   };
+
+  config.finalConfig.files = lib.mapAttrsToList (relPath: op: {
+    target = relPath;
+    source = toString op.resolvedSource;
+    inherit (op) mode location;
+  }) config.files;
 }

--- a/readme.md
+++ b/readme.md
@@ -64,10 +64,24 @@ See [options.md](options.md) for all available options
           ];
         };
       };
-
       vrchat = {
         id = 438100;
         launchOptions.env.TZ = null;
+      };
+
+      "620" = {
+        # Drop files into the install dir or Proton prefix. Backups of
+        # replaced files land next to the original with a
+        # `.steam-config-nix-backup` suffix on first apply.
+        files = {
+          # Stub a file with empty content.
+          "path/to/intro.bik".empty = true;
+          # First-apply config the in-game overlay edits in place.
+          "some-config.ini" = {
+            source = ./some-config.ini;
+            mode = "init";
+          };
+        };
       };
     };
   };

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -1,0 +1,127 @@
+"""Per-app file drops into Steam install dirs and Proton prefixes.
+
+Used for game mods, asset replacements, DLL injections, and first-apply
+config templates the game writes back to. Backups of replaced files are
+written once next to the target with `.steam-config-nix-backup` suffix on
+first apply.
+"""
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from srctools import steam
+
+from steam_config_patcher.types import FileOpConfig, FilesConfig
+
+LOG = logging.getLogger(__name__)
+BACKUP_SUFFIX = ".steam-config-nix-backup"
+
+
+def _find_install_dir(app_id: int) -> Optional[Path]:
+    """Resolve `<library>/steamapps/common/<installdir>` for `app_id`.
+
+    Returns `None` when the app is not installed in any registered library.
+    """
+    try:
+        return steam.find_app(app_id).path
+    except KeyError:
+        return None
+
+
+def _find_compat_prefix(app_id: int) -> Optional[Path]:
+    """Resolve `<library>/steamapps/compatdata/<app_id>/pfx` for `app_id`.
+
+    The compatdata directory lives next to common/ in the same library, so
+    we resolve via the install path. Returns `None` if the app or its
+    prefix is missing (e.g. the user has never launched the game so Proton
+    hasn't created the prefix yet).
+    """
+    install = _find_install_dir(app_id)
+    if install is None:
+        return None
+    # …/<library>/steamapps/common/<installdir>
+    #   .parents[0] = …/<library>/steamapps/common
+    #   .parents[1] = …/<library>/steamapps
+    pfx = install.parents[1] / "compatdata" / str(app_id) / "pfx"
+    return pfx if pfx.is_dir() else None
+
+
+def _resolve_root(app_id: int, location: str) -> Optional[Path]:
+    if location == "install":
+        return _find_install_dir(app_id)
+    if location == "prefix":
+        return _find_compat_prefix(app_id)
+    raise ValueError(f"unknown location {location!r}")
+
+
+def _apply_file_op(app_id: int, op: FileOpConfig) -> None:
+    root = _resolve_root(app_id, op.location)
+    if root is None:
+        LOG.warning(
+            "app %d: %s root not found, skipping %s",
+            app_id,
+            op.location,
+            op.target,
+        )
+        return
+
+    target = root / op.target
+    source = Path(op.source)
+    target_existed = target.exists()
+
+    # `replace` is a no-op when the target doesn't exist; the operator opted
+    # into "only act when the file is already there".
+    if not target_existed and op.mode == "replace":
+        LOG.warning(
+            "app %d: target %s does not exist (mode=replace), skipping",
+            app_id,
+            target,
+        )
+        return
+
+    # `init` writes only on first apply, then it's user-owned. Even if the
+    # source content drifted (e.g. a new tuning landed in the host config),
+    # leave the on-disk file alone so in-game overlay edits and other user
+    # changes are preserved across re-applies. Push a new template by
+    # deleting the target and re-running.
+    if target_existed and op.mode == "init":
+        return
+
+    # Already applied — bytes match. Skip the rewrite + chmod churn.
+    if target_existed and target.is_file() and source.is_file():
+        if target.read_bytes() == source.read_bytes():
+            return
+
+    # Back up the original (once), if it existed. We never overwrite an
+    # existing backup, so the very first state we saw is what gets preserved.
+    backup = target.with_name(target.name + BACKUP_SUFFIX)
+    if target_existed and not backup.exists():
+        shutil.copy2(target, backup)
+        LOG.info("backed up %s -> %s", target, backup)
+
+    if not target_existed:
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(source, target)
+    # /nix/store sources are 0o444; copy2 carries those bits across, leaving
+    # the dropped file read-only. Any app that writes back to a dropped
+    # config file (in-game overlays, save files, settings panels) would then
+    # fail with EACCES. Force a writable mode so user/in-app edits can
+    # persist; `init` mode then keeps them across re-applies.
+    target.chmod(0o644)
+
+    if op.mode == "init":
+        verb = "initialized"
+    elif target_existed:
+        verb = "replaced"
+    else:
+        verb = "created"
+    LOG.info("%s %s", verb, target)
+
+
+def apply_file_drops(file_drops: list[FilesConfig]) -> None:
+    for entry in file_drops:
+        for op in entry.files:
+            _apply_file_op(entry.app_id, op)

--- a/src/steam_config_patcher/main.py
+++ b/src/steam_config_patcher/main.py
@@ -10,16 +10,26 @@ from steam_config_patcher.patcher import patch_config_files
 from steam_config_patcher.steam import get_steam_user_ids
 from steam_config_patcher.types import (
     CompatToolConfig,
+    FileOpConfig,
+    FilesConfig,
     NonSteamAppConfig,
     PatcherConfig,
     UserConfig,
 )
 
 
+class FileOpSchema(BaseModel):
+    target: str
+    source: str
+    mode: str  # "replace" | "create" | "init"; validated by FileOpConfig
+    location: str  # "install" | "prefix"; validated by FileOpConfig
+
+
 class AppSchema(BaseModel):
     id: int
     launchOptions: Optional[str] = None
     compatTool: Optional[str] = None
+    files: list[FileOpSchema] = []
 
 
 class NonSteamAppSchema(AppSchema):
@@ -96,6 +106,22 @@ def parse_input() -> PatcherConfig:
             )
             for user_id in get_steam_user_ids(steam_dir)
         },
+        file_drops=[
+            FilesConfig(
+                app_id=app.id,
+                files=[
+                    FileOpConfig(
+                        target=op.target,
+                        source=Path(op.source),
+                        mode=op.mode,  # type: ignore[arg-type]
+                        location=op.location,  # type: ignore[arg-type]
+                    )
+                    for op in app.files
+                ],
+            )
+            for app in validated_input.apps.values()
+            if app.files
+        ],
     )
 
 

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -1,5 +1,6 @@
 import vdf
 
+from steam_config_patcher.files import apply_file_drops
 from steam_config_patcher.formats.binary_keyvalues import patch_binary_keyvalues
 from steam_config_patcher.formats.keyvalues import patch_keyvalues
 from steam_config_patcher.types import ConfigPatch, PatcherConfig, UserConfig
@@ -119,6 +120,10 @@ def generate_shortcuts_vdf_patch(
 
 
 def patch_config_files(cfg: PatcherConfig):
+    # File drops first -- they don't need Steam closed and are independent of
+    # the vdf-patching path below.
+    apply_file_drops(cfg.file_drops)
+
     config_patches = [
         generate_config_vdf_patch(cfg),
         *[

--- a/src/steam_config_patcher/types.py
+++ b/src/steam_config_patcher/types.py
@@ -17,6 +17,20 @@ class NonSteamAppConfig:
 
 
 @dataclass
+class FileOpConfig:
+    target: str  # path relative to install/prefix root
+    source: Path  # absolute path on disk (typically /nix/store/...)
+    mode: Literal["replace", "create", "init"]
+    location: Literal["install", "prefix"]
+
+
+@dataclass
+class FilesConfig:
+    app_id: int
+    files: list[FileOpConfig]
+
+
+@dataclass
 class UserConfig:
     launch_options: dict[int, str]
     non_steam_apps: dict[int, NonSteamAppConfig]
@@ -34,6 +48,7 @@ class PatcherConfig:
     steam_dir: Path
     compat_tool_mapping: dict[int, CompatToolConfig]
     users: dict[int, UserConfig]
+    file_drops: list[FilesConfig]
 
 
 KeyValuesValue = str | int


### PR DESCRIPTION
I created this module in order to facilitate file overrides, especially with mods. I had my own nix module I wrote for this, then I discovered this project so I'm porting this over :)

It does things all relative to the actual data dir or prefix of the app id, it's all explained in the doc strings.