### PR TITLE
feat(modules): add name of the game in generated script

### DIFF
--- a/modules/submodules/base-app.nix
+++ b/modules/submodules/base-app.nix
@@ -58,6 +58,8 @@ let
           "exec env ${lib.replaceString "%command%" ''"$@"'' app.launchOptionsStr}"
         else if hasOptions then
           ''
+            # Steam configuration for ${name}
+
             ${exportAll app.launchOptions.env}
 
             declare -a wrappers=(${lib.escapeShellArgs app.launchOptions.wrappers})

--- a/modules/submodules/base-app.nix
+++ b/modules/submodules/base-app.nix
@@ -68,7 +68,7 @@ let
 
             ${app.launchOptions.preHook}
 
-              exec env "''${wrappers[@]}" "''${game_command[@]}" "''${args[@]}"
+            exec env "''${wrappers[@]}" "''${game_command[@]}" "''${args[@]}"
           ''
         else
           ''exec "$@"'';


### PR DESCRIPTION
Title, makes it a little more explicit when looking at scripts in `~/.local/share/steam-config-nix/apps/` which configures what.

Is also included, a commit that removes two whitespaces in front of the `exec` because they messed up the indentation and it irritated my inner perfectionist.