### PR TITLE
feat: add displayRatesAsBits option for download rate units

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -40,6 +40,7 @@ let
     builtins.toJSON {
       onSteamRunning = "wait";
       defaultCompatTool = null;
+      displayRatesAsBits = true;
       apps."Test Game" = {
         id = 620;
         compatTool = "GE-Proton";
@@ -338,6 +339,7 @@ in
 
         grep -q GE-Proton "$steam/config/config.vdf"
         grep -q test-launch-wrapper "$lc"
+        grep -q '"displayratesasbits"[[:space:]]*"1"' "$lc"
         grep -q '"BetaKey"' "$acf"
         grep -q beta "$acf"
         grep -q german "$acf"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -151,6 +151,17 @@ in
       '';
     };
 
+    displayRatesAsBits = lib.mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Whether to display download rates in bits per second.
+
+        Set to `false` for MB/s (bytes), `true` for Mb/s (bits). `null` leaves the existing Steam setting untouched.
+      '';
+    };
+
     apps = lib.mkOption {
       type = mkAppType steamAppModule;
       default = { };
@@ -242,6 +253,7 @@ in
       patcherConfig = builtins.toJSON {
         inherit (cfg) onSteamRunning;
         defaultCompatTool = mkCompatToolValue cfg.defaultCompatTool;
+        displayRatesAsBits = cfg.displayRatesAsBits;
         apps = mapFinalConfigs enabledApps;
         nonSteamApps = mapFinalConfigs enabledNonSteamApps;
       };
@@ -290,17 +302,22 @@ in
                 lib.concatLists (
                   lib.mapAttrsToList (
                     appName: app:
-                    lib.concatMap (
-                      location:
-                      lib.mapAttrsToList (path: entry: {
-                        inherit
-                          appName
-                          location
-                          path
-                          entry
-                          ;
-                      }) app.files.${location}
-                    ) [ "install" "prefix" ]
+                    lib.concatMap
+                      (
+                        location:
+                        lib.mapAttrsToList (path: entry: {
+                          inherit
+                            appName
+                            location
+                            path
+                            entry
+                            ;
+                        }) app.files.${location}
+                      )
+                      [
+                        "install"
+                        "prefix"
+                      ]
                   ) enabledApps
                 )
               );
@@ -308,9 +325,12 @@ in
               removeEntries = lib.concatLists (
                 lib.mapAttrsToList (
                   appName: app:
-                  lib.concatMap (
-                    location: map (target: { inherit appName location target; }) app.removeFiles.${location}
-                  ) [ "install" "prefix" ]
+                  lib.concatMap
+                    (location: map (target: { inherit appName location target; }) app.removeFiles.${location})
+                    [
+                      "install"
+                      "prefix"
+                    ]
                 ) enabledApps
               );
 
@@ -318,9 +338,7 @@ in
 
               duplicateTargets = lib.filter (group: lib.length group > 1) (
                 builtins.attrValues (
-                  builtins.groupBy (
-                    e: "${e.appName}\n${e.location}\n${e.entry.target}"
-                  ) enabledFileEntries
+                  builtins.groupBy (e: "${e.appName}\n${e.location}\n${e.entry.target}") enabledFileEntries
                 )
               );
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -251,9 +251,8 @@ in
       );
 
       patcherConfig = builtins.toJSON {
-        inherit (cfg) onSteamRunning;
+        inherit (cfg) onSteamRunning displayRatesAsBits;
         defaultCompatTool = mkCompatToolValue cfg.defaultCompatTool;
-        displayRatesAsBits = cfg.displayRatesAsBits;
         apps = mapFinalConfigs enabledApps;
         nonSteamApps = mapFinalConfigs enabledNonSteamApps;
       };

--- a/src/steam_config_patcher/main.py
+++ b/src/steam_config_patcher/main.py
@@ -78,6 +78,7 @@ class NonSteamAppSchema(AppSchema):
 class InputSchema(StrictSchema):
     onSteamRunning: Literal["wait", "close", "force-close", "skip"]
     defaultCompatTool: CompatToolValue
+    displayRatesAsBits: Optional[bool] = None
     apps: dict[str, AppSchema]
     nonSteamApps: dict[str, NonSteamAppSchema]
 
@@ -110,6 +111,7 @@ def parse_input() -> PatcherConfig:
     return PatcherConfig(
         on_steam_running=validated_input.onSteamRunning,
         steam_dir=steam_dir,
+        display_rates_as_bits=validated_input.displayRatesAsBits,
         compat_tool_mapping={
             app.id: CompatToolConfig(
                 name=resolve_compat_tool(app.compatTool),

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -24,6 +24,7 @@ from steam_config_patcher.types import (
     APPMANIFEST_PATH,
     COMPAT_TOOL_MAPPING_PATH,
     CONFIG_FILE,
+    DISPLAY_RATES_AS_BITS_PATH,
     LOCALCONFIG_APPS_PATH,
     LOCALCONFIG_FILE,
     ConfigPatch,
@@ -158,6 +159,7 @@ def generate_appmanifest_patch(
 
 
 def localconfig_vdf_state(
+    cfg: PatcherConfig,
     user_config: UserConfig,
 ) -> tuple[KeyValuesLeaves, list[ManagedKey]]:
     leaves: KeyValuesLeaves = {}
@@ -171,6 +173,18 @@ def localconfig_vdf_state(
                 file=LOCALCONFIG_FILE,
                 key_path=key_path,
                 expected=launch_options,
+            )
+        )
+
+    if cfg.display_rates_as_bits is not None:
+        leaves[DISPLAY_RATES_AS_BITS_PATH] = (
+            "1" if cfg.display_rates_as_bits else "0"
+        )
+        managed_keys.append(
+            ManagedKey(
+                file=LOCALCONFIG_FILE,
+                key_path=DISPLAY_RATES_AS_BITS_PATH,
+                expected="1" if cfg.display_rates_as_bits else "0",
             )
         )
 
@@ -211,7 +225,7 @@ def generate_localconfig_vdf_patch(
     user_config: UserConfig,
     prev_manifest: UserManifest,
 ) -> ConfigPatch:
-    leaves, desired_keys = localconfig_vdf_state(user_config)
+    leaves, desired_keys = localconfig_vdf_state(cfg, user_config)
 
     return ConfigPatch(
         file_path=cfg.steam_dir.joinpath(
@@ -316,7 +330,7 @@ def prepare_patch(config_patch: ConfigPatch) -> Optional[bytes]:
 
 def desired_manifest(cfg: PatcherConfig, user_config: UserConfig) -> UserManifest:
     _, config_keys = config_vdf_state(cfg)
-    _, localconfig_keys = localconfig_vdf_state(user_config)
+    _, localconfig_keys = localconfig_vdf_state(cfg, user_config)
 
     return UserManifest(
         managed_keys=config_keys + game_appmanifest_keys(cfg) + localconfig_keys,

--- a/src/steam_config_patcher/types.py
+++ b/src/steam_config_patcher/types.py
@@ -4,6 +4,11 @@ from typing import Literal, Optional, Union
 
 CONFIG_FILE = "config"
 LOCALCONFIG_FILE = "localconfig"
+DISPLAY_RATES_AS_BITS_PATH = (
+    "UserLocalConfigStore",
+    "system",
+    "displayratesasbits",
+)
 APPMANIFEST_FILE_PREFIX = "appmanifest_"
 
 APPMANIFEST_PATH = ("AppState",)
@@ -69,6 +74,7 @@ class PatcherConfig:
     steam_dir: Path
     compat_tool_mapping: dict[int, CompatToolConfig]
     users: dict[int, UserConfig]
+    display_rates_as_bits: Optional[bool] = None
     game_betas: dict[int, str] = field(default_factory=dict)
     game_languages: dict[int, str] = field(default_factory=dict)
     game_update_behaviors: dict[int, str] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- Add a top-level `programs.steam.steam-config.displayRatesAsBits` option (`null` / `true` / `false`)
- When set, patch `UserLocalConfigStore.system.displayratesasbits` in `localconfig.vdf` so Steam shows download rates in bits (`true` / Mb/s) or bytes (`false` / MB/s)
- `null` leaves the existing Steam setting untouched
- This was created  by Grok btw

## Example usage
```
programs.steam = {
    enable = true;
    remotePlay.openFirewall = true;
    dedicatedServer.openFirewall = true;
    extraCompatPackages = with pkgs; [
      proton-cachyos-x86_64-v3
    ];
    config = {
      enable = true;
      onSteamRunning = "close";
      defaultCompatTool = pkgs.proton-cachyos-x86_64-v3;
      displayRatesAsBits = false; # This PR implements this option
    };
  };
```
<img width="819" height="247" alt="image" src="https://github.com/user-attachments/assets/5c489ccf-2876-4387-90bd-04b1075faa48" />
