### PR TITLE
fix(patcher): also look into `bin` sub-directory for compat tool

### DIFF
--- a/src/steam_config_patcher/compat.py
+++ b/src/steam_config_patcher/compat.py
@@ -4,8 +4,15 @@ from steam_config_patcher.vdf import text
 
 
 def resolve_compat_tool_name(tool_dir: Path) -> str:
-    vdf_path = tool_dir / "compatibilitytool.vdf"
-    if not vdf_path.is_file():
+    vdf_paths = [
+        tool_dir / "compatibilitytool.vdf",
+        tool_dir / "bin" / "compatibilitytool.vdf",
+    ]
+
+    for vdf_path in vdf_paths:
+        if vdf_path.is_file():
+            break
+    else:
         raise FileNotFoundError(f"no compatibilitytool.vdf found in {tool_dir}")
 
     root = text.loads(vdf_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Some proton packages like [chaotic-nyx](https://www.nyx.chaotic.cx/)'s `proton-cachyos`/`proton-cachyos_x86_64_v3` have their stuff in a `bin/` directory.

This PR makes the patcher search into `bin/` for the `compatibilitytool.vdf` file if it cannot find it.

<details>

<summary>python traceback in systemd logs</summary>

```log
2026-08-04 00:27 systemd[14021]: steam-config-patcher.service: Failed with result 'exit-code'.
2026-08-04 00:27 systemd[14021]: steam-config-patcher.service: Main process exited, code=exited, status=1/FAILURE
2026-08-04 00:27 steam-config-patcher[475036]: FileNotFoundError: no compatibilitytool.vdf found in /nix/store/gg8hx67nv2fmgzrjzqkz66lmgxbfrzgd-proton-cachyos
2026-08-04 00:27 steam-config-patcher[475036]:     raise FileNotFoundError(f"no compatibilitytool.vdf found in {tool_dir}")
2026-08-04 00:27 steam-config-patcher[475036]:   File "/nix/store/xvmmyk262by4qnw8zff1qzm2km86hzad-steam-config-patcher-0.4.0/lib/python3.14/site-packages/steam_config_patcher/compat.py", line 9, in resolve_compat_tool_name
2026-08-04 00:27 steam-config-patcher[475036]:     return resolve_compat_tool_name(Path(compat_tool.path))
2026-08-04 00:27 steam-config-patcher[475036]:   File "/nix/store/xvmmyk262by4qnw8zff1qzm2km86hzad-steam-config-patcher-0.4.0/lib/python3.14/site-packages/steam_config_patcher/main.py", line 88, in resolve_compat_tool
2026-08-04 00:27 steam-config-patcher[475036]:          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
2026-08-04 00:27 steam-config-patcher[475036]:     name=resolve_compat_tool(app.compatTool),
2026-08-04 00:27 steam-config-patcher[475036]:   File "/nix/store/xvmmyk262by4qnw8zff1qzm2km86hzad-steam-config-patcher-0.4.0/lib/python3.14/site-packages/steam_config_patcher/main.py", line 117, in parse_input
2026-08-04 00:27 steam-config-patcher[475036]:     cfg = parse_input()
2026-08-04 00:27 steam-config-patcher[475036]:   File "/nix/store/xvmmyk262by4qnw8zff1qzm2km86hzad-steam-config-patcher-0.4.0/lib/python3.14/site-packages/steam_config_patcher/main.py", line 210, in main
2026-08-04 00:27 steam-config-patcher[475036]:              ~~~~^^
2026-08-04 00:27 steam-config-patcher[475036]:     sys.exit(main())
2026-08-04 00:27 steam-config-patcher[475036]:   File "/nix/store/xvmmyk262by4qnw8zff1qzm2km86hzad-steam-config-patcher-0.4.0/bin/.steam-config-patcher-wrapped", line 9, in <module>
2026-08-04 00:27 steam-config-patcher[475036]: Traceback (most recent call last):
2026-08-04 00:27 systemd[14021]: Started Steam config patcher script.
2026-08-04 00:27 systemd[14021]: Starting Steam config patcher script...
```

</details>