### PR TITLE
refactor(patcher): modernize, precise and explicit typing more

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 description = "Patch Steam vdf files using JSON input"
 authors = [{ name = "different-name", email = "hello@different-name.dev" }]
 dependencies = ["pydantic", "psutil", "pillow"]
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 license = { text = "GPL-3.0" }
 
 [project.scripts]

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -5,6 +5,7 @@ import shutil
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import Callable
 
 from steam_config_patcher.files_manifest import (
     backup_path,
@@ -13,6 +14,7 @@ from steam_config_patcher.files_manifest import (
 )
 from steam_config_patcher.steam import find_app_compat_prefix, find_app_install_dir
 from steam_config_patcher.types import (
+    FileLocation,
     FileOp,
     FilesManifest,
     ManagedDir,
@@ -22,7 +24,7 @@ from steam_config_patcher.types import (
 
 LOG = logging.getLogger(__name__)
 
-FileKey = tuple[int, str, str]
+FileKey = tuple[int, FileLocation, str]
 
 
 class FileOpConflict(ValueError):
@@ -32,7 +34,7 @@ class FileOpConflict(ValueError):
 @dataclass
 class _Placement:
     app_id: int
-    location: str
+    location: FileLocation
     target: str
     source_file: Path
     overwrite_changes: bool
@@ -125,7 +127,7 @@ def _resolve_placements(file_ops: list[FileOp]) -> dict[FileKey, _Placement]:
 
 
 def _dirs_to_create(root: Path, target: str) -> list[str]:
-    created = []
+    created: list[str] = []
     current = root
     for part in PurePosixPath(target).parts[:-1]:
         current = current / part
@@ -228,7 +230,7 @@ def _remove_targets(
 
 
 def _remove_one(
-    steam_dir: Path, root: Path, app_id: int, location: str, target: str,
+    steam_dir: Path, root: Path, app_id: int, location: FileLocation, target: str,
     prev: ManagedFile | None,
 ) -> ManagedFile | None:
     target_path = root / target
@@ -263,9 +265,9 @@ def _cleanup_removed_dir(root: Path, target: str) -> None:
 
 
 def _cleanup_created_dirs(
-    created: set[FileKey], root_for
+    created: set[FileKey], root_for: Callable[[int, str], Path | None]
 ) -> list[ManagedDir]:
-    survivors = []
+    survivors: list[ManagedDir] = []
     for app_id, location, target in sorted(
         created, key=lambda item: len(PurePosixPath(item[2]).parts), reverse=True
     ):
@@ -337,7 +339,9 @@ def apply_file_ops(
     ):
         return
 
-    prev = {(e.app_id, e.location, e.target): e for e in prev_manifest.files}
+    prev: dict[tuple[int, FileLocation, str], ManagedFile] = (
+        {(e.app_id, e.location, e.target): e for e in prev_manifest.files}
+    )
 
     root_cache: dict[tuple[int, str], Path | None] = {}
 
@@ -356,7 +360,9 @@ def apply_file_ops(
 
     new_files: list[ManagedFile] = []
     desired: set[FileKey] = set()
-    created_dirs = {(d.app_id, d.location, d.target) for d in prev_manifest.dirs}
+    created_dirs: set[tuple[int, FileLocation, str]] = (
+        {(d.app_id, d.location, d.target) for d in prev_manifest.dirs}
+    )
 
     for key, placement in placements.items():
         desired.add(key)

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -2,10 +2,9 @@ import hashlib
 import logging
 import os
 import shutil
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Callable
 
 from steam_config_patcher.files_manifest import (
     backup_path,
@@ -339,9 +338,9 @@ def apply_file_ops(
     ):
         return
 
-    prev: dict[tuple[int, FileLocation, str], ManagedFile] = (
-        {(e.app_id, e.location, e.target): e for e in prev_manifest.files}
-    )
+    prev: dict[FileKey, ManagedFile] = {
+        (e.app_id, e.location, e.target): e for e in prev_manifest.files
+    }
 
     root_cache: dict[tuple[int, str], Path | None] = {}
 
@@ -360,9 +359,9 @@ def apply_file_ops(
 
     new_files: list[ManagedFile] = []
     desired: set[FileKey] = set()
-    created_dirs: set[tuple[int, FileLocation, str]] = (
-        {(d.app_id, d.location, d.target) for d in prev_manifest.dirs}
-    )
+    created_dirs: set[FileKey] = {
+        (d.app_id, d.location, d.target) for d in prev_manifest.dirs
+    }
 
     for key, placement in placements.items():
         desired.add(key)

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -23,7 +23,7 @@ from steam_config_patcher.types import (
 
 LOG = logging.getLogger(__name__)
 
-FileKey = tuple[int, FileLocation, str]
+type FileKey = tuple[int, FileLocation, str]
 
 
 class FileOpConflict(ValueError):

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -2,9 +2,9 @@ import hashlib
 import logging
 import os
 import shutil
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Iterator, Optional
 
 from steam_config_patcher.files_manifest import (
     backup_path,
@@ -36,7 +36,7 @@ class _Placement:
     target: str
     source_file: Path
     overwrite_changes: bool
-    executable: Optional[bool]
+    executable: bool | None
     specificity: int
     declared: str
 
@@ -49,7 +49,7 @@ def _hash_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _resolve_mode(executable: Optional[bool], source_file: Path) -> int:
+def _resolve_mode(executable: bool | None, source_file: Path) -> int:
     if executable is True:
         return 0o755
     if executable is False:
@@ -152,8 +152,8 @@ def _atomic_place(source_file: Path, target_path: Path, mode: int) -> None:
 
 
 def _place_one(
-    steam_dir: Path, root: Path, placement: _Placement, prev: Optional[ManagedFile]
-) -> Optional[ManagedFile]:
+    steam_dir: Path, root: Path, placement: _Placement, prev: ManagedFile | None
+) -> ManagedFile | None:
     target_path = root / placement.target
     is_symlink = target_path.is_symlink()
     exists = target_path.exists() or is_symlink
@@ -229,8 +229,8 @@ def _remove_targets(
 
 def _remove_one(
     steam_dir: Path, root: Path, app_id: int, location: str, target: str,
-    prev: Optional[ManagedFile],
-) -> Optional[ManagedFile]:
+    prev: ManagedFile | None,
+) -> ManagedFile | None:
     target_path = root / target
     if not (target_path.exists() or target_path.is_symlink()):
         return prev
@@ -285,7 +285,7 @@ def _cleanup_created_dirs(
     return survivors
 
 
-def _revert_one(steam_dir: Path, root: Optional[Path], entry: ManagedFile) -> None:
+def _revert_one(steam_dir: Path, root: Path | None, entry: ManagedFile) -> None:
     stored = backup_path(steam_dir, entry.app_id, entry.location, entry.target)
 
     if root is None:
@@ -339,9 +339,9 @@ def apply_file_ops(
 
     prev = {(e.app_id, e.location, e.target): e for e in prev_manifest.files}
 
-    root_cache: dict[tuple[int, str], Optional[Path]] = {}
+    root_cache: dict[tuple[int, str], Path | None] = {}
 
-    def root_for(app_id: int, location: str) -> Optional[Path]:
+    def root_for(app_id: int, location: str) -> Path | None:
         cache_key = (app_id, location)
         if cache_key not in root_cache:
             root_cache[cache_key] = (

--- a/src/steam_config_patcher/files.py
+++ b/src/steam_config_patcher/files.py
@@ -216,7 +216,9 @@ def _remove_targets(
 ) -> Iterator[str]:
     base = root / remove_op.target
     if base.is_dir() and not base.is_symlink():
-        candidates = (p.relative_to(root).as_posix() for p in _iter_dir_files(base))
+        candidates: Iterator[str] = (
+            p.relative_to(root).as_posix() for p in _iter_dir_files(base)
+        )
     elif base.exists() or base.is_symlink():
         candidates = iter([remove_op.target])
     else:

--- a/src/steam_config_patcher/files_manifest.py
+++ b/src/steam_config_patcher/files_manifest.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Optional
 
 from steam_config_patcher.json_manifest import load_json_manifest, save_json_manifest
 from steam_config_patcher.types import FilesManifest, ManagedDir, ManagedFile
@@ -22,7 +21,7 @@ def backup_path(steam_dir: Path, app_id: int, location: str, target: str) -> Pat
     )
 
 
-def _parse(raw: dict) -> Optional[FilesManifest]:
+def _parse(raw: dict) -> FilesManifest | None:
     version = raw.get("version")
     if version != FILES_MANIFEST_VERSION:
         LOG.warning("ignoring files manifest with unknown version %s", version)

--- a/src/steam_config_patcher/formats/binary_keyvalues.py
+++ b/src/steam_config_patcher/formats/binary_keyvalues.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any
 
 from steam_config_patcher.types import ConfigPatch, Deletion
 from steam_config_patcher.vdf.binary import dumps, loads
@@ -39,7 +39,7 @@ def recursive_update(destination: dict[Any, Any], source: dict[Any, Any]) -> boo
     return modified
 
 
-def prepare_binary_keyvalues(config_patch: ConfigPatch) -> Optional[bytes]:
+def prepare_binary_keyvalues(config_patch: ConfigPatch) -> bytes | None:
     if config_patch.file_path.is_file():
         kv = loads(config_patch.file_path.read_bytes())
     else:

--- a/src/steam_config_patcher/formats/binary_keyvalues.py
+++ b/src/steam_config_patcher/formats/binary_keyvalues.py
@@ -40,11 +40,12 @@ def recursive_update(destination: dict[Any, Any], source: dict[Any, Any]) -> boo
 
 
 def prepare_binary_keyvalues(config_patch: ConfigPatch) -> bytes | None:
+    kv: dict[Any, Any]
     if config_patch.file_path.is_file():
         kv = loads(config_patch.file_path.read_bytes())
     else:
         # no existing file, start fresh so new entries can be created
-        kv: dict[Any, Any] = {}
+        kv = {}
 
     modified = recursive_update(kv, config_patch.data)
 

--- a/src/steam_config_patcher/formats/keyvalues.py
+++ b/src/steam_config_patcher/formats/keyvalues.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Optional
+from collections.abc import Iterator
 
 from steam_config_patcher.types import (
     ConfigPatch,
@@ -86,7 +86,7 @@ def delete_key(kv: VdfNode, deletion: Deletion) -> bool:
     return modified
 
 
-def prepare_keyvalues(config_patch: ConfigPatch) -> Optional[bytes]:
+def prepare_keyvalues(config_patch: ConfigPatch) -> bytes | None:
     if not config_patch.file_path.is_file():
         return None
 

--- a/src/steam_config_patcher/formats/keyvalues.py
+++ b/src/steam_config_patcher/formats/keyvalues.py
@@ -8,7 +8,7 @@ from steam_config_patcher.types import (
 )
 from steam_config_patcher.vdf.text import VdfNode, dumps, loads
 
-KeyPath = tuple[*tuple[str, ...], str]
+type KeyPath = tuple[*tuple[str, ...], str]
 
 
 def iterate_leaves(

--- a/src/steam_config_patcher/formats/keyvalues.py
+++ b/src/steam_config_patcher/formats/keyvalues.py
@@ -8,7 +8,7 @@ from steam_config_patcher.types import (
 )
 from steam_config_patcher.vdf.text import VdfNode, dumps, loads
 
-type KeyPath = tuple[*tuple[str, ...], str]
+type KeyPath = tuple[str, ...]
 
 
 def iterate_leaves(
@@ -60,9 +60,10 @@ def guard_matches(node: VdfNode, deletion: Deletion) -> bool:
     for key in deletion.guard_path:
         if not target.is_block:
             return False
-        target = target.find(key)
-        if target is None:
+        found = target.find(key)
+        if found is None:
             return False
+        target = found
 
     return not target.is_block and target.value == deletion.expected
 

--- a/src/steam_config_patcher/icons.py
+++ b/src/steam_config_patcher/icons.py
@@ -2,7 +2,6 @@ import io
 import logging
 import os
 from pathlib import Path
-from typing import Optional
 
 from PIL import Image
 
@@ -37,7 +36,7 @@ def _remove_managed_icons(hicolor: Path) -> None:
             LOG.warning("could not remove %s", path, exc_info=True)
 
 
-def _librarycache_icon(steam_dir: Path, app_id: int, hash_: str) -> Optional[Path]:
+def _librarycache_icon(steam_dir: Path, app_id: int, hash_: str) -> Path | None:
     directory = steam_dir.joinpath("appcache", "librarycache", str(app_id))
     for ext in (".jpg", ".png", ".ico"):
         candidate = directory / f"{hash_}{ext}"
@@ -54,8 +53,8 @@ def _render_png(source: Path) -> tuple[bytes, tuple[int, int]]:
         return buffer.getvalue(), rgba.size
 
 
-def _fallback_icon() -> Optional[Path]:
-    best: Optional[Path] = None
+def _fallback_icon() -> Path | None:
+    best: Path | None = None
     best_size = -1
     for base in _icon_search_bases():
         hicolor = base / "hicolor"
@@ -84,7 +83,7 @@ def _write_icon(hicolor: Path, app_id: int, data: bytes, size: tuple[int, int]) 
 
 def _resolve_source(
     steam_dir: Path, app_id: int, common: dict[int, dict]
-) -> Optional[Path]:
+) -> Path | None:
     entry = common.get(app_id)
     if entry is None:
         return None

--- a/src/steam_config_patcher/json_manifest.py
+++ b/src/steam_config_patcher/json_manifest.py
@@ -2,16 +2,13 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TypeVar
 
 from steam_config_patcher.fileio import atomic_write_text
 
 LOG = logging.getLogger(__name__)
 
-T = TypeVar("T")
 
-
-def load_json_manifest(
+def load_json_manifest[T](
     path: Path, parse: Callable[[dict], T | None], default: T
 ) -> T:
     if not path.is_file():

--- a/src/steam_config_patcher/json_manifest.py
+++ b/src/steam_config_patcher/json_manifest.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Callable, Optional, TypeVar
+from typing import Callable, TypeVar
 
 from steam_config_patcher.fileio import atomic_write_text
 
@@ -11,7 +11,7 @@ T = TypeVar("T")
 
 
 def load_json_manifest(
-    path: Path, parse: Callable[[dict], Optional[T]], default: T
+    path: Path, parse: Callable[[dict], T | None], default: T
 ) -> T:
     if not path.is_file():
         return default

--- a/src/steam_config_patcher/json_manifest.py
+++ b/src/steam_config_patcher/json_manifest.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 from steam_config_patcher.fileio import atomic_write_text
 

--- a/src/steam_config_patcher/main.py
+++ b/src/steam_config_patcher/main.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -29,14 +29,14 @@ class CompatToolRefSchema(StrictSchema):
     path: str
 
 
-CompatToolValue = Optional[Union[str, CompatToolRefSchema]]
+CompatToolValue = str | CompatToolRefSchema | None
 
 
 class ArtworkSchema(StrictSchema):
-    cover: Optional[str] = None
-    header: Optional[str] = None
-    hero: Optional[str] = None
-    logo: Optional[str] = None
+    cover: str | None = None
+    header: str | None = None
+    hero: str | None = None
+    logo: str | None = None
 
 
 class FileOpSchema(StrictSchema):
@@ -44,7 +44,7 @@ class FileOpSchema(StrictSchema):
     target: str
     source: str
     overwriteChanges: bool
-    executable: Optional[bool] = None
+    executable: bool | None = None
 
 
 class RemoveOpSchema(StrictSchema):
@@ -54,11 +54,11 @@ class RemoveOpSchema(StrictSchema):
 
 class AppSchema(StrictSchema):
     id: int
-    launchOptions: Optional[str] = None
+    launchOptions: str | None = None
     compatTool: CompatToolValue = None
-    betaBranch: Optional[str] = None
-    language: Optional[str] = None
-    updateBehavior: Optional[str] = None
+    betaBranch: str | None = None
+    language: str | None = None
+    updateBehavior: str | None = None
     libraryIcon: bool = False
     artwork: ArtworkSchema = Field(default_factory=ArtworkSchema)
     files: list[FileOpSchema] = Field(default_factory=list)
@@ -68,8 +68,8 @@ class AppSchema(StrictSchema):
 class NonSteamAppSchema(AppSchema):
     name: str
     target: str
-    startIn: Optional[str]
-    icon: Optional[str]
+    startIn: str | None
+    icon: str | None
     isHidden: bool
     allowOverlay: bool
     inVrLibrary: bool
@@ -78,12 +78,12 @@ class NonSteamAppSchema(AppSchema):
 class InputSchema(StrictSchema):
     onSteamRunning: Literal["wait", "close", "force-close", "skip"]
     defaultCompatTool: CompatToolValue
-    displayRatesAsBits: Optional[bool] = None
+    displayRatesAsBits: bool | None = None
     apps: dict[str, AppSchema]
     nonSteamApps: dict[str, NonSteamAppSchema]
 
 
-def resolve_compat_tool(compat_tool: CompatToolValue) -> Optional[str]:
+def resolve_compat_tool(compat_tool: CompatToolValue) -> str | None:
     if isinstance(compat_tool, CompatToolRefSchema):
         return resolve_compat_tool_name(Path(compat_tool.path))
     return compat_tool

--- a/src/steam_config_patcher/main.py
+++ b/src/steam_config_patcher/main.py
@@ -114,7 +114,7 @@ def parse_input() -> PatcherConfig:
         display_rates_as_bits=validated_input.displayRatesAsBits,
         compat_tool_mapping={
             app.id: CompatToolConfig(
-                name=resolve_compat_tool(app.compatTool),
+                name=name,
                 priority=250 if app.id != 0 else 75,
             )
             for app in [
@@ -123,6 +123,7 @@ def parse_input() -> PatcherConfig:
                 AppSchema(id=0, compatTool=validated_input.defaultCompatTool),
             ]
             if app.compatTool
+            and (name := resolve_compat_tool(app.compatTool)) is not None
         },
         game_betas={
             app.id: app.betaBranch

--- a/src/steam_config_patcher/main.py
+++ b/src/steam_config_patcher/main.py
@@ -29,7 +29,7 @@ class CompatToolRefSchema(StrictSchema):
     path: str
 
 
-CompatToolValue = str | CompatToolRefSchema | None
+type CompatToolValue = str | CompatToolRefSchema | None
 
 
 class ArtworkSchema(StrictSchema):

--- a/src/steam_config_patcher/manifest.py
+++ b/src/steam_config_patcher/manifest.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Optional
 
 from steam_config_patcher.json_manifest import load_json_manifest, save_json_manifest
 from steam_config_patcher.types import (
@@ -62,7 +61,7 @@ def _parse_v2(raw: dict) -> UserManifest:
     )
 
 
-def _parse(raw: dict) -> Optional[UserManifest]:
+def _parse(raw: dict) -> UserManifest | None:
     version = raw.get("version")
     if version == 1:
         return _parse_v1(raw)

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -448,7 +448,7 @@ def patch_config_files(cfg: PatcherConfig):
     if skip_files:
         LOG.warning(
             "A game is running; skipped file operations. "
-            + 'Close the game, or set onSteamRunning to "wait" or "close" to apply automatically.'
+            'Close the game, or set onSteamRunning to "wait" or "close" to apply automatically.'
         )
     else:
         try:
@@ -462,7 +462,7 @@ def patch_config_files(cfg: PatcherConfig):
     if blocked:
         LOG.warning(
             "Steam is running; skipped Steam config writes. "
-            + 'Close Steam, or set onSteamRunning to "wait" or "close" to apply automatically.'
+            'Close Steam, or set onSteamRunning to "wait" or "close" to apply automatically.'
         )
         return
 

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 from steam_config_patcher.fileio import atomic_write_bytes
@@ -48,7 +48,9 @@ def nest_leaves(leaves: KeyValuesLeaves) -> KeyValuesType:
     for key_path, value in leaves.items():
         node = tree
         for key in key_path[:-1]:
-            node = node.setdefault(key, {})
+            child = node.setdefault(key, {})
+            assert isinstance(child, dict)
+            node = child
         node[key_path[-1]] = value
     return tree
 
@@ -358,7 +360,7 @@ def patch_config_files(cfg: PatcherConfig):
         }
     )
 
-    patch_steps = [
+    patch_steps: list[tuple[str, Callable[[], ConfigPatch | None]]] = [
         ("config.vdf", lambda: generate_config_vdf_patch(cfg, all_prev_keys)),
         *[
             (
@@ -396,7 +398,9 @@ def patch_config_files(cfg: PatcherConfig):
         for description, generate in patch_steps:
             try:
                 config_patch = generate()
-                data = None if config_patch is None else prepare_patch(config_patch)
+                if config_patch is None:
+                    continue
+                data = prepare_patch(config_patch)
             except Exception:
                 failed.add(description)
                 LOG.exception("failed to prepare %s", description)

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import assert_never
 
 from steam_config_patcher.fileio import atomic_write_bytes
 from steam_config_patcher.files import apply_file_ops
@@ -328,7 +329,8 @@ def prepare_patch(config_patch: ConfigPatch) -> bytes | None:
             return prepare_keyvalues(config_patch)
         case "binary-keyvalues":
             return prepare_binary_keyvalues(config_patch)
-    return None
+        case unreachable:
+            assert_never(unreachable)
 
 
 def desired_manifest(cfg: PatcherConfig, user_config: UserConfig) -> UserManifest:

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 from steam_config_patcher.fileio import atomic_write_bytes
 from steam_config_patcher.files import apply_file_ops
@@ -77,7 +77,7 @@ def appmanifest_file_id(app_id: int) -> str:
     return f"{APPMANIFEST_FILE_PREFIX}{app_id}"
 
 
-def appmanifest_app_id(file_id: str) -> Optional[int]:
+def appmanifest_app_id(file_id: str) -> int | None:
     if not file_id.startswith(APPMANIFEST_FILE_PREFIX):
         return None
     suffix = file_id.removeprefix(APPMANIFEST_FILE_PREFIX)
@@ -123,7 +123,7 @@ def configured_appmanifest_ids(cfg: PatcherConfig) -> set[int]:
 
 def generate_appmanifest_patch(
     cfg: PatcherConfig, app_id: int, prev_keys: Iterable[ManagedKey]
-) -> Optional[ConfigPatch]:
+) -> ConfigPatch | None:
     file_id = appmanifest_file_id(app_id)
     settings = appmanifest_settings(cfg, app_id)
 
@@ -319,7 +319,7 @@ def generate_shortcuts_vdf_patch(
     )
 
 
-def prepare_patch(config_patch: ConfigPatch) -> Optional[bytes]:
+def prepare_patch(config_patch: ConfigPatch) -> bytes | None:
     match config_patch.file_format:
         case "keyvalues":
             return prepare_keyvalues(config_patch)

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -40,7 +40,7 @@ from steam_config_patcher.vdf import binary
 
 LOG = logging.getLogger(__name__)
 
-KeyValuesLeaves = dict[tuple[str, ...], str]
+type KeyValuesLeaves = dict[tuple[str, ...], str]
 
 
 def nest_leaves(leaves: KeyValuesLeaves) -> KeyValuesType:

--- a/src/steam_config_patcher/patcher.py
+++ b/src/steam_config_patcher/patcher.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable
+from pathlib import Path
 
 from steam_config_patcher.fileio import atomic_write_bytes
 from steam_config_patcher.files import apply_file_ops
@@ -54,7 +55,7 @@ def nest_leaves(leaves: KeyValuesLeaves) -> KeyValuesType:
 
 def config_vdf_state(cfg: PatcherConfig) -> tuple[KeyValuesLeaves, list[ManagedKey]]:
     leaves: KeyValuesLeaves = {}
-    managed_keys = []
+    managed_keys: list[ManagedKey] = []
 
     for app_id, compat_tool in cfg.compat_tool_mapping.items():
         block_path = COMPAT_TOOL_MAPPING_PATH + (str(app_id),)
@@ -88,7 +89,7 @@ def appmanifest_settings(
     cfg: PatcherConfig, app_id: int
 ) -> list[tuple[tuple[str, ...], str]]:
     # each entry is a key path relative to AppState, with the value to write
-    settings = []
+    settings: list[tuple[tuple[str, ...], str]] = []
     beta_branch = cfg.game_betas.get(app_id)
     if beta_branch is not None:
         settings.append((("UserConfig", APPMANIFEST_BETA_KEY), beta_branch))
@@ -163,7 +164,7 @@ def localconfig_vdf_state(
     user_config: UserConfig,
 ) -> tuple[KeyValuesLeaves, list[ManagedKey]]:
     leaves: KeyValuesLeaves = {}
-    managed_keys = []
+    managed_keys: list[ManagedKey] = []
 
     for app_id, launch_options in user_config.launch_options.items():
         key_path = LOCALCONFIG_APPS_PATH + (str(app_id), "LaunchOptions")
@@ -390,8 +391,8 @@ def patch_config_files(cfg: PatcherConfig):
 
     failed: set[str] = set()
 
-    def prepare_all():
-        prepared = []
+    def prepare_all() -> list[tuple[str, Path, bytes]]:
+        prepared: list[tuple[str, Path, bytes]] = []
         for description, generate in patch_steps:
             try:
                 config_patch = generate()
@@ -447,7 +448,7 @@ def patch_config_files(cfg: PatcherConfig):
     if skip_files:
         LOG.warning(
             "A game is running; skipped file operations. "
-            'Close the game, or set onSteamRunning to "wait" or "close" to apply automatically.'
+            + 'Close the game, or set onSteamRunning to "wait" or "close" to apply automatically.'
         )
     else:
         try:
@@ -461,7 +462,7 @@ def patch_config_files(cfg: PatcherConfig):
     if blocked:
         LOG.warning(
             "Steam is running; skipped Steam config writes. "
-            'Close Steam, or set onSteamRunning to "wait" or "close" to apply automatically.'
+            + 'Close Steam, or set onSteamRunning to "wait" or "close" to apply automatically.'
         )
         return
 

--- a/src/steam_config_patcher/steam.py
+++ b/src/steam_config_patcher/steam.py
@@ -48,7 +48,11 @@ def steam_library_paths(steam_dir: Path) -> list[Path]:
                 if not folder.is_block:
                     continue
                 path_node = folder.find("path")
-                if path_node is not None and not path_node.is_block:
+                if (
+                    path_node is not None
+                    and not path_node.is_block
+                    and path_node.value is not None
+                ):
                     paths.append(Path(path_node.value))
         break
 

--- a/src/steam_config_patcher/steam.py
+++ b/src/steam_config_patcher/steam.py
@@ -52,8 +52,8 @@ def steam_library_paths(steam_dir: Path) -> list[Path]:
                     paths.append(Path(path_node.value))
         break
 
-    seen = set()
-    unique = []
+    seen: set[str] = set()
+    unique: list[Path] = []
     for path in paths:
         if str(path) not in seen:
             seen.add(str(path))
@@ -94,7 +94,7 @@ def find_app_compat_prefix(steam_dir: Path, app_id: int) -> Path | None:
 
 def steam_processes() -> list[psutil.Process]:
     uid = os.getuid()
-    processes = []
+    processes: list[psutil.Process] = []
     for proc in psutil.process_iter(["name"]):
         try:
             if proc.info["name"] == "steam" and proc.uids().real == uid:
@@ -110,7 +110,7 @@ def steam_is_running() -> bool:
 
 def game_processes() -> list[psutil.Process]:
     uid = os.getuid()
-    processes = []
+    processes: list[psutil.Process] = []
     for proc in psutil.process_iter(["name", "cmdline"]):
         try:
             if proc.info["name"] != "reaper" or proc.uids().real != uid:

--- a/src/steam_config_patcher/steam.py
+++ b/src/steam_config_patcher/steam.py
@@ -3,7 +3,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Optional
 
 import psutil
 
@@ -62,7 +61,7 @@ def steam_library_paths(steam_dir: Path) -> list[Path]:
     return unique
 
 
-def find_app_manifest(steam_dir: Path, app_id: int) -> Optional[Path]:
+def find_app_manifest(steam_dir: Path, app_id: int) -> Path | None:
     for library in steam_library_paths(steam_dir):
         manifest = library.joinpath("steamapps", f"appmanifest_{app_id}.acf")
         if manifest.is_file():
@@ -70,7 +69,7 @@ def find_app_manifest(steam_dir: Path, app_id: int) -> Optional[Path]:
     return None
 
 
-def find_app_install_dir(steam_dir: Path, app_id: int) -> Optional[Path]:
+def find_app_install_dir(steam_dir: Path, app_id: int) -> Path | None:
     manifest = find_app_manifest(steam_dir, app_id)
     if manifest is None:
         return None
@@ -84,7 +83,7 @@ def find_app_install_dir(steam_dir: Path, app_id: int) -> Optional[Path]:
     return install_dir if install_dir.is_dir() else None
 
 
-def find_app_compat_prefix(steam_dir: Path, app_id: int) -> Optional[Path]:
+def find_app_compat_prefix(steam_dir: Path, app_id: int) -> Path | None:
     manifest = find_app_manifest(steam_dir, app_id)
     if manifest is None:
         return None

--- a/src/steam_config_patcher/types.py
+++ b/src/steam_config_patcher/types.py
@@ -84,8 +84,8 @@ class PatcherConfig:
     remove_ops: list["RemoveOp"] = field(default_factory=list)
 
 
-KeyValuesValue = str | int
-KeyValuesType = dict[str, "KeyValuesValue | KeyValuesType"]
+type KeyValuesValue = str | int
+type KeyValuesType = dict[str, KeyValuesValue | KeyValuesType]
 
 
 @dataclass
@@ -125,7 +125,7 @@ class UserManifest:
     grid_art: dict[str, str] = field(default_factory=dict)
 
 
-FileLocation = Literal["install", "prefix"]
+type FileLocation = Literal["install", "prefix"]
 
 
 @dataclass

--- a/src/steam_config_patcher/types.py
+++ b/src/steam_config_patcher/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 CONFIG_FILE = "config"
 LOCALCONFIG_FILE = "localconfig"
@@ -50,10 +50,10 @@ GRID_SLOTS = (
 
 @dataclass
 class GridArt:
-    cover: Optional[str] = None
-    header: Optional[str] = None
-    hero: Optional[str] = None
-    logo: Optional[str] = None
+    cover: str | None = None
+    header: str | None = None
+    hero: str | None = None
+    logo: str | None = None
 
 
 @dataclass
@@ -74,7 +74,7 @@ class PatcherConfig:
     steam_dir: Path
     compat_tool_mapping: dict[int, CompatToolConfig]
     users: dict[int, UserConfig]
-    display_rates_as_bits: Optional[bool] = None
+    display_rates_as_bits: bool | None = None
     game_betas: dict[int, str] = field(default_factory=dict)
     game_languages: dict[int, str] = field(default_factory=dict)
     game_update_behaviors: dict[int, str] = field(default_factory=dict)
@@ -85,14 +85,14 @@ class PatcherConfig:
 
 
 KeyValuesValue = str | int
-KeyValuesType = dict[str, Union[KeyValuesValue, "KeyValuesType"]]
+KeyValuesType = dict[str, "KeyValuesValue | KeyValuesType"]
 
 
 @dataclass
 class Deletion:
     key_path: tuple[str, ...]
     guard_path: tuple[str, ...] = ()
-    expected: Optional[str] = None
+    expected: str | None = None
 
 
 @dataclass(frozen=True)
@@ -100,7 +100,7 @@ class ManagedKey:
     file: str
     key_path: tuple[str, ...]
     guard_path: tuple[str, ...] = ()
-    expected: Optional[str] = None
+    expected: str | None = None
 
     def to_deletion(self) -> Deletion:
         return Deletion(
@@ -134,9 +134,9 @@ class ManagedFile:
     location: FileLocation
     target: str
     op: Literal["place", "remove"]
-    source_hash: Optional[str] = None
+    source_hash: str | None = None
     had_backup: bool = False
-    source_path: Optional[str] = None
+    source_path: str | None = None
 
 
 @dataclass
@@ -146,7 +146,7 @@ class FileOp:
     target: str
     source: Path
     overwrite_changes: bool
-    executable: Optional[bool] = None
+    executable: bool | None = None
 
 
 @dataclass

--- a/src/steam_config_patcher/vdf/appinfo.py
+++ b/src/steam_config_patcher/vdf/appinfo.py
@@ -46,7 +46,7 @@ def load_common(data: bytes, app_ids: set[int] | None = None) -> dict[int, dict]
         raise AppInfoError(f"unsupported appinfo.vdf version 0x{magic:08x}")
 
     offset = _HEADER.size
-    read_key = binary._read_cstring
+    read_key: binary.KeyReader = binary._read_cstring
     if magic == MAGIC_V41:
         (string_table_offset,) = _STRING_TABLE_OFFSET.unpack_from(data, offset)
         offset += _STRING_TABLE_OFFSET.size

--- a/src/steam_config_patcher/vdf/appinfo.py
+++ b/src/steam_config_patcher/vdf/appinfo.py
@@ -1,5 +1,4 @@
 import struct
-from typing import Optional
 
 from steam_config_patcher.vdf import binary
 
@@ -41,7 +40,7 @@ def _string_table_key_reader(strings: list[str]) -> binary.KeyReader:
     return read_key
 
 
-def load_common(data: bytes, app_ids: Optional[set[int]] = None) -> dict[int, dict]:
+def load_common(data: bytes, app_ids: set[int] | None = None) -> dict[int, dict]:
     (magic, _universe) = _HEADER.unpack_from(data, 0)
     if magic not in (MAGIC_V40, MAGIC_V41):
         raise AppInfoError(f"unsupported appinfo.vdf version 0x{magic:08x}")
@@ -75,7 +74,7 @@ def load_common(data: bytes, app_ids: Optional[set[int]] = None) -> dict[int, di
     return result
 
 
-def _find_common(block: dict) -> Optional[dict]:
+def _find_common(block: dict) -> dict | None:
     for value in block.values():
         if isinstance(value, dict):
             common = value.get("common")
@@ -84,7 +83,7 @@ def _find_common(block: dict) -> Optional[dict]:
     return None
 
 
-def icon_hash(common: dict) -> Optional[str]:
+def icon_hash(common: dict) -> str | None:
     for key in ("icon", "clienticon"):
         value = common.get(key)
         if isinstance(value, str) and value:

--- a/src/steam_config_patcher/vdf/appinfo.py
+++ b/src/steam_config_patcher/vdf/appinfo.py
@@ -19,7 +19,7 @@ class AppInfoError(ValueError):
 def _read_string_table(data: bytes, offset: int) -> list[str]:
     (count,) = _UINT32.unpack_from(data, offset)
     position = offset + _UINT32.size
-    strings = []
+    strings: list[str] = []
     for _ in range(count):
         end = data.find(b"\x00", position)
         if end == -1:

--- a/src/steam_config_patcher/vdf/binary.py
+++ b/src/steam_config_patcher/vdf/binary.py
@@ -1,5 +1,5 @@
 import struct
-from typing import Callable, Union
+from typing import Callable
 
 _TYPE_DICT = 0x00
 _TYPE_STRING = 0x01
@@ -15,7 +15,7 @@ _UINT64 = struct.Struct("<Q")
 _INT64 = struct.Struct("<q")
 _FLOAT32 = struct.Struct("<f")
 
-BinaryVdfValue = Union[dict, str, int, float]
+BinaryVdfValue = dict | str | int | float
 
 
 class Uint64(int):

--- a/src/steam_config_patcher/vdf/binary.py
+++ b/src/steam_config_patcher/vdf/binary.py
@@ -57,6 +57,7 @@ def _read_dict(
 
         key, offset = read_key(data, offset)
 
+        value: BinaryVdfValue
         if value_type == _TYPE_DICT:
             value, offset = _read_dict(data, offset, top_level=False, read_key=read_key)
         elif value_type == _TYPE_STRING:

--- a/src/steam_config_patcher/vdf/binary.py
+++ b/src/steam_config_patcher/vdf/binary.py
@@ -1,5 +1,5 @@
 import struct
-from typing import Callable
+from collections.abc import Callable
 
 _TYPE_DICT = 0x00
 _TYPE_STRING = 0x01
@@ -15,7 +15,7 @@ _UINT64 = struct.Struct("<Q")
 _INT64 = struct.Struct("<q")
 _FLOAT32 = struct.Struct("<f")
 
-BinaryVdfValue = dict | str | int | float
+type BinaryVdfValue = dict | str | int | float
 
 
 class Uint64(int):
@@ -37,7 +37,7 @@ def _read_cstring(data: bytes, offset: int) -> tuple[str, int]:
     return data[offset:end].decode("utf-8"), end + 1
 
 
-KeyReader = Callable[[bytes, int], tuple[str, int]]
+type KeyReader = Callable[[bytes, int], tuple[str, int]]
 
 
 def _read_dict(

--- a/src/steam_config_patcher/vdf/text.py
+++ b/src/steam_config_patcher/vdf/text.py
@@ -16,7 +16,7 @@ class VdfSyntaxError(ValueError):
 
 
 class VdfNode:
-    __slots__: tuple[str, str, str] = ("name", "value", "children")
+    __slots__ = ("name", "value", "children")
 
     def __init__(
         self,

--- a/src/steam_config_patcher/vdf/text.py
+++ b/src/steam_config_patcher/vdf/text.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import override
 
 _ESCAPES = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}
 _UNESCAPES = {"\\": "\\\\", '"': '\\"', "\n": "\\n", "\t": "\\t", "\r": "\\r"}
@@ -11,11 +12,11 @@ _TOKEN_CLOSE = "close"
 class VdfSyntaxError(ValueError):
     def __init__(self, message: str, line: int):
         super().__init__(f"{message} (line {line})")
-        self.line = line
+        self.line: int = line
 
 
 class VdfNode:
-    __slots__ = ("name", "value", "children")
+    __slots__: tuple[str, str, str] = ("name", "value", "children")
 
     def __init__(
         self,
@@ -23,14 +24,15 @@ class VdfNode:
         value: str | None = None,
         children: list["VdfNode"] | None = None,
     ):
-        self.name = name
-        self.value = value
-        self.children = children
+        self.name: str | None = name
+        self.value: str | None = value
+        self.children: list[VdfNode] | None = children
 
     @property
     def is_block(self) -> bool:
         return self.children is not None
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, VdfNode):
             return NotImplemented
@@ -40,6 +42,7 @@ class VdfNode:
             and self.children == other.children
         )
 
+    @override
     def __repr__(self) -> str:
         if self.is_block:
             return f"VdfNode({self.name!r}, children={self.children!r})"
@@ -87,7 +90,7 @@ class VdfNode:
 
 
 def _read_quoted(text: str, start: int, line: int) -> tuple[str, int, int]:
-    parts = []
+    parts: list[str] = []
     i = start + 1
     while i < len(text):
         c = text[i]

--- a/src/steam_config_patcher/vdf/text.py
+++ b/src/steam_config_patcher/vdf/text.py
@@ -20,11 +20,11 @@ class VdfNode:
 
     def __init__(
         self,
-        name: str | None = None,
+        name: str = "",
         value: str | None = None,
         children: list["VdfNode"] | None = None,
     ):
-        self.name: str | None = name
+        self.name: str = name
         self.value: str | None = value
         self.children: list[VdfNode] | None = children
 
@@ -63,6 +63,8 @@ class VdfNode:
         return next(self.find_all(name), None)
 
     def remove(self, name: str) -> bool:
+        if self.children is None:
+            return False
         folded = name.casefold()
         remaining = [c for c in self.children if c.name.casefold() != folded]
         removed = len(remaining) != len(self.children)
@@ -79,11 +81,13 @@ class VdfNode:
             )
             if block is None:
                 block = VdfNode(name, children=[])
+                assert node.children is not None
                 node.children.append(block)
             node = block
 
         leaf = next((c for c in node.find_all(leaf_name) if not c.is_block), None)
         if leaf is None:
+            assert node.children is not None
             node.children.append(VdfNode(leaf_name, value=value))
         else:
             leaf.value = value
@@ -158,11 +162,13 @@ def loads(text: str) -> VdfNode:
             else:
                 raise VdfSyntaxError("unexpected '{'", token_line)
         else:
+            top = stack[-1]
+            assert top.children is not None
             if token_type == _TOKEN_STRING:
-                stack[-1].children.append(VdfNode(pending_key, value=token_value))
+                top.children.append(VdfNode(pending_key, value=token_value))
             elif token_type == _TOKEN_OPEN:
                 block = VdfNode(pending_key, children=[])
-                stack[-1].children.append(block)
+                top.children.append(block)
                 stack.append(block)
             else:
                 raise VdfSyntaxError(f"key {pending_key!r} has no value", token_line)
@@ -182,17 +188,18 @@ def _escape(value: str) -> str:
 
 def _write_node(node: VdfNode, depth: int, parts: list[str]) -> None:
     indent = "\t" * depth
-    if node.is_block:
+    if node.children is not None:
         parts.append(f'{indent}"{_escape(node.name)}"\n{indent}{{\n')
         for child in node.children:
             _write_node(child, depth + 1, parts)
         parts.append(f"{indent}}}\n")
     else:
+        assert node.value is not None
         parts.append(f'{indent}"{_escape(node.name)}"\t\t"{_escape(node.value)}"\n')
 
 
 def dumps(root: VdfNode) -> str:
     parts: list[str] = []
-    for child in root.children:
+    for child in root.children or []:
         _write_node(child, 0, parts)
     return "".join(parts)

--- a/src/steam_config_patcher/vdf/text.py
+++ b/src/steam_config_patcher/vdf/text.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Optional
+from collections.abc import Iterator
 
 _ESCAPES = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}
 _UNESCAPES = {"\\": "\\\\", '"': '\\"', "\n": "\\n", "\t": "\\t", "\r": "\\r"}
@@ -19,9 +19,9 @@ class VdfNode:
 
     def __init__(
         self,
-        name: Optional[str] = None,
-        value: Optional[str] = None,
-        children: Optional[list["VdfNode"]] = None,
+        name: str | None = None,
+        value: str | None = None,
+        children: list["VdfNode"] | None = None,
     ):
         self.name = name
         self.value = value
@@ -56,7 +56,7 @@ class VdfNode:
             elif child.is_block:
                 yield from child.find_all(*rest)
 
-    def find(self, name: str) -> Optional["VdfNode"]:
+    def find(self, name: str) -> "VdfNode | None":
         return next(self.find_all(name), None)
 
     def remove(self, name: str) -> bool:
@@ -106,7 +106,7 @@ def _read_quoted(text: str, start: int, line: int) -> tuple[str, int, int]:
     raise VdfSyntaxError("unterminated string", line)
 
 
-def _tokenize(text: str) -> Iterator[tuple[str, Optional[str], int]]:
+def _tokenize(text: str) -> Iterator[tuple[str, str | None, int]]:
     i = 0
     line = 1
     length = len(text)
@@ -140,7 +140,7 @@ def _tokenize(text: str) -> Iterator[tuple[str, Optional[str], int]]:
 def loads(text: str) -> VdfNode:
     root = VdfNode(children=[])
     stack = [root]
-    pending_key: Optional[str] = None
+    pending_key: str | None = None
     line = 1
 
     for token_type, token_value, token_line in _tokenize(text):


### PR DESCRIPTION
Assuming the target Python version is at least 3.11 (because the synthax [at this line](https://github.com/different-name/steam-config-nix/blob/36c3dc1cfa60a5ce4032bcd801b094e770d8b871/src/steam_config_patcher/formats/keyvalues.py#L11) was added [then](https://peps.python.org/pep-0646/)):

## First commit:

- Some stuff (like `Iterator`) were moved from `typing` to `collections.abc` in [PEP 585](https://peps.python.org/pep-0585/)  (3.9)
- Use [PEP 604](https://peps.python.org/pep-0604/)'s `|` to replace `Union`s and `Optional`s from `typing` (3.10)

## Second commit 

Tries to fix, precise and explicit more typing. I initially wanted to comply with mypy but I didn't want to rewrite too much logic.