### PR TITLE
test(checks): set `system.stateVersion` to silence warning

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -89,6 +89,7 @@
         modules = [
           self.nixosModules.default
           {
+            system.stateVersion = "26.05";
             nixpkgs.hostPlatform = system;
             programs.steam.config = {
               enable = true;
@@ -382,6 +383,7 @@
               modules = [
                 self.nixosModules.default
                 {
+                  system.stateVersion = "26.05";
                   nixpkgs.hostPlatform = system;
                   programs.steam.config = {
                     enable = true;


### PR DESCRIPTION
Simple PR to silences the following warning when running `nix flake check`:

```
evaluation warning: system.stateVersion is not set, defaulting to 25.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
evaluation warning: system.stateVersion is not set, defaulting to 25.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
```