### PR TITLE
fix(modules): write game name in addition to ID

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -282,6 +282,13 @@
                           scope.properties.Slice = "games.slice";
                         };
                       };
+                      "1002" = {
+                        name = ''Sven "Co-op"'';
+                        systemd = {
+                          enable = true;
+                          target.name = "sven-co-op";
+                        };
+                      };
                       "220" = { };
                     };
                   };
@@ -294,6 +301,7 @@
             appTarget = pkgs.writeText "app-target" units."steam-app-vrchat.target".text;
             sharedTarget = pkgs.writeText "shared-target" units."steam-app.target".text;
             wrapper = steamConfig.apps."438100".wrapper.package;
+            quotedNameWrapper = steamConfig.apps."1002".wrapper.package;
           in
           pkgs.runCommand "systemd-targets" { } (
             assert lib.assertMsg (
@@ -311,6 +319,10 @@
               grep -q 'systemd-run --user --scope' "$wrapper"
               grep -q 'property=Wants=steam-app-vrchat.target' "$wrapper"
               grep -q 'property=Slice=games.slice' "$wrapper"
+
+              quoted=${quotedNameWrapper}/bin/steam-app-wrapper-1002
+              grep -q "scn_app_name='Sven" "$quoted"
+              grep -q 'launching ''$scn_app_name without a scope' "$quoted"
 
               touch $out
             ''

--- a/modules/submodules/base-app-wrapper.nix
+++ b/modules/submodules/base-app-wrapper.nix
@@ -21,6 +21,8 @@ let
     body:
     lib.optionalString steamConfig.notifications ''( unset LD_LIBRARY_PATH LD_PRELOAD; ${lib.getExe' pkgs.libnotify "notify-send"} -a steam-config-nix "steam-config-nix" "${body}" ) >/dev/null 2>&1 || true'';
 
+  displayName = if config.name == name then name else "${config.name} (${name})";
+
   mkAppWrapperPackage =
     app:
     let
@@ -109,7 +111,7 @@ let
           ''"''${game_command[@]}"'';
 
       scopeProperties = {
-        Description = name;
+        Description = displayName;
         Wants = app.systemd.target.unitName;
         After = app.systemd.target.unitName;
       }
@@ -129,8 +131,8 @@ let
             ${lib.escapeShellArgs (lib.mapAttrsToList mkPropertyArg scopeProperties)}
           )
         else
-          echo "steam-config-nix: no systemd user manager, launching without a scope" >&2
-          ${notify "No systemd user manager, launching ${name} without a scope"}
+          echo "steam-config-nix: no systemd user manager, launching ${displayName} without a scope" >&2
+          ${notify "No systemd user manager, launching ${displayName} without a scope"}
         fi
       '';
 
@@ -139,7 +141,7 @@ let
       launch =
         if hasOptions then
           ''
-            # Steam configuration for ${name}${lib.optionalString (config.name != name) " (${config.name})"}
+            # Steam configuration for ${displayName}
 
             ${exportAll app.env}
 

--- a/modules/submodules/base-app-wrapper.nix
+++ b/modules/submodules/base-app-wrapper.nix
@@ -131,8 +131,9 @@ let
             ${lib.escapeShellArgs (lib.mapAttrsToList mkPropertyArg scopeProperties)}
           )
         else
-          echo "steam-config-nix: no systemd user manager, launching ${displayName} without a scope" >&2
-          ${notify "No systemd user manager, launching ${displayName} without a scope"}
+          scn_app_name=${lib.escapeShellArg displayName}
+          echo "steam-config-nix: no systemd user manager, launching $scn_app_name without a scope" >&2
+          ${notify "No systemd user manager, launching $scn_app_name without a scope"}
         fi
       '';
 

--- a/modules/submodules/base-app-wrapper.nix
+++ b/modules/submodules/base-app-wrapper.nix
@@ -139,7 +139,7 @@ let
       launch =
         if hasOptions then
           ''
-            # Steam configuration for ${name}
+            # Steam configuration for ${name}${lib.optionalString (config.name != name) " (${config.name})"}
 
             ${exportAll app.env}
 


### PR DESCRIPTION
This should render the game name from the config after the changes in https://github.com/different-name/steam-config-nix/commit/5497a73cc1f3b5b3a3a5ab69801e54fdc47b063b. I can remove the conditional if it's not ideal. Did not test this change.

Before:

``` bash
# Steam configuration for 225840
```

After:

``` bash
# Steam configuration for 225840 (Sven Co-op)
```