### PR TITLE
chore: update flake inputs

### DIFF
--- a/docs/flake.lock
+++ b/docs/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787559586,
-        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787962033,
-        "narHash": "sha256-u6z9VTZA4Kf3RkHQo9sQI7NI4Ei/uiU9vrMqOiwWP1Y=",
+        "lastModified": 1788690626,
+        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5c4a43b0e8056328ec4529f735cabdb8f1942bb",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787559586,
-        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787962033,
-        "narHash": "sha256-u6z9VTZA4Kf3RkHQo9sQI7NI4Ei/uiU9vrMqOiwWP1Y=",
+        "lastModified": 1788690626,
+        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5c4a43b0e8056328ec4529f735cabdb8f1942bb",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
unpacking 'github:hercules-ci/flake-parts/31729ca8cbdb4fa927b34e5f4353e6a83f39e993' into the Git cache...
unpacking 'github:nixos/nixpkgs/c25784012c9982bca5b3e0de87e90bbdac8927d3' into the Git cache...
unpacking 'github:nix-systems/x86_64-linux/2ecfcac5e15790ba6ce360ceccddb15ad16d08a8' into the Git cache...
warning: updating lock file "/home/runner/work/steam-config-nix/steam-config-nix/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/9d0d871' (2026-08-24)
  → 'github:hercules-ci/flake-parts/31729ca' (2026-09-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c5c4a43' (2026-08-29)
  → 'github:nixos/nixpkgs/c257840' (2026-09-06)
warning: Git tree '/home/runner/work/steam-config-nix/steam-config-nix' has uncommitted changes
unpacking 'github:imfing/hextra/8e53e7a7ef3e24348edbac276e03cb9fecf66d0c' into the Git cache...
unpacking 'github:NuschtOS/search/fdf7b70e332f918ccf34f4e4a5a47a8c718ea1a9' into the Git cache...
warning: updating lock file "/home/runner/work/steam-config-nix/steam-config-nix/docs/flake.lock":
• Updated input 'steam-config-nix':
    'path:..'
  → 'path:..'
• Updated input 'steam-config-nix/flake-parts':
    'github:hercules-ci/flake-parts/9d0d871' (2026-08-24)
  → 'github:hercules-ci/flake-parts/31729ca' (2026-09-03)
• Updated input 'steam-config-nix/nixpkgs':
    'github:nixos/nixpkgs/c5c4a43' (2026-08-29)
  → 'github:nixos/nixpkgs/c257840' (2026-09-06)
